### PR TITLE
Add A-Team to default team list

### DIFF
--- a/internal/app/engine/config.go
+++ b/internal/app/engine/config.go
@@ -14,6 +14,7 @@ var defaultTeams = []string{
 	"Unknown",
 	"AIS",
 	"AMC",
+	"A-Team",
 	"CMμs",
 	"ER-Force",
 	"Immortals",


### PR DESCRIPTION
Just adding our new team's name to the default config file.