### PR TITLE
Add new team "ibis" to config.go

### DIFF
--- a/internal/app/engine/config.go
+++ b/internal/app/engine/config.go
@@ -22,6 +22,7 @@ var defaultTeams = []string{
 	"Eagles",
 	"ER-Force",
 	"GreenTea",
+	"ibis",
 	"Immortals",
 	"ITAndroids",
 	"KgpKubs",


### PR DESCRIPTION
Hi, we are "ibis", a new SSL team in japan.
https://www.ibis-ssl.tokyo/

Can you add our team?