### PR TITLE
Allow specifying the Team->GC and Autoref->GC addresses via command line

### DIFF
--- a/cmd/ssl-game-controller/main.go
+++ b/cmd/ssl-game-controller/main.go
@@ -14,6 +14,8 @@ import (
 )
 
 var address = flag.String("address", "localhost:8081", "The address on which the UI and API is served")
+var autorefAddress = flag.String("autorefAddress", "", "The address on which the Autoref -> GC connection is served")
+var teamAddress = flag.String("teamAddress", "", "The address on which the Team -> GC connection is served")
 var ciAddress = flag.String("ciAddress", "", "The address on which the CI connection is served")
 var visionAddress = flag.String("visionAddress", "", "The address (ip+port) from which vision packages are received")
 var trackerAddress = flag.String("trackerAddress", "", "The address (ip+port) from which tracker packages are received")
@@ -67,6 +69,12 @@ func setupGameController() {
 	}
 	if ciAddress != nil && *ciAddress != "" {
 		cfg.Server.Ci.Address = *ciAddress
+	}
+	if autorefAddress != nil && *autorefAddress != "" {
+		cfg.Server.AutoRef.Address = *autorefAddress
+	}
+	if teamAddress != nil && *teamAddress != "" {
+		cfg.Server.Team.Address = *teamAddress
 	}
 
 	gameController := gc.NewGameController(cfg)

--- a/cmd/ssl-game-controller/main.go
+++ b/cmd/ssl-game-controller/main.go
@@ -16,6 +16,7 @@ import (
 var address = flag.String("address", "localhost:8081", "The address on which the UI and API is served")
 var autorefAddress = flag.String("autorefAddress", "", "The address on which the Autoref -> GC connection is served")
 var teamAddress = flag.String("teamAddress", "", "The address on which the Team -> GC connection is served")
+var remoteControlAddress = flag.String("remoteControlAddress", "", "The address on which the remote control connection is served")
 var ciAddress = flag.String("ciAddress", "", "The address on which the CI connection is served")
 var visionAddress = flag.String("visionAddress", "", "The address (ip+port) from which vision packages are received")
 var trackerAddress = flag.String("trackerAddress", "", "The address (ip+port) from which tracker packages are received")
@@ -75,6 +76,9 @@ func setupGameController() {
 	}
 	if teamAddress != nil && *teamAddress != "" {
 		cfg.Server.Team.Address = *teamAddress
+	}
+	if remoteControlAddress != nil && *remoteControlAddress != "" {
+		cfg.Server.RemoteControl.Address = *remoteControlAddress
 	}
 
 	gameController := gc.NewGameController(cfg)


### PR DESCRIPTION
Against what I expected people from our team actually use multiple instances of our Software, so it'd be nice to specify this