### PR TITLE
Fixes Auto Game State when Ball is Too Close to Defensive Area

### DIFF
--- a/internal/app/engine/common.go
+++ b/internal/app/engine/common.go
@@ -174,3 +174,18 @@ func (e *Engine) isBallInAnyDefenseArea() (bool, state.Team) {
 	}
 	return false, state.Team_UNKNOWN
 }
+
+// ballTooCloseToDefenseArea returns true if the ball is within BallPlacementMinDistanceToDefenseArea of either
+// defense area. This is the single source of truth for the placement keep-out check and must be used by both
+// the check that decides whether placement is required and the check that gates auto-continue readiness,
+// otherwise the two can silently drift apart.
+func (e *Engine) ballTooCloseToDefenseArea(ballPos *geom.Vector2) bool {
+	for _, sign := range []float64{1, -1} {
+		defenseArea := geom.NewDefenseAreaBySign(e.getGeometry(), sign)
+		forbiddenArea := defenseArea.WithMargin(e.gameConfig.BallPlacementMinDistanceToDefenseArea)
+		if forbiddenArea.IsPointInside(ballPos) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/engine/process_continue_next_action.go
+++ b/internal/app/engine/process_continue_next_action.go
@@ -354,12 +354,8 @@ func (e *Engine) ballPlacementRequired() bool {
 	}
 
 	// The ball is at least 0.7m away from any defense area.
-	for _, sign := range []float64{1, -1} {
-		defenseArea := geom.NewDefenseAreaBySign(e.getGeometry(), sign)
-		forbiddenArea := defenseArea.WithMargin(e.gameConfig.BallPlacementMinDistanceToDefenseArea)
-		if forbiddenArea.IsPointInside(ballPos) {
-			return true
-		}
+	if e.ballTooCloseToDefenseArea(ballPos) {
+		return true
 	}
 
 	return false

--- a/internal/app/engine/process_continue_next_command.go
+++ b/internal/app/engine/process_continue_next_command.go
@@ -217,6 +217,7 @@ func (e *Engine) readyToContinueFromStop() (issues []string) {
 		issues = append(issues, "Blue team has too many robots")
 	}
 	radius := e.gameConfig.DistanceToBallInStop + robotRadius - distanceThreshold
+	ballPos := e.trackerStateGc.Ball.Pos.ToVector2()
 
 	var robots []*Robot
 	if e.currentState.NextCommand != nil && *e.currentState.NextCommand.Type == state.Command_DIRECT {
@@ -227,7 +228,7 @@ func (e *Engine) readyToContinueFromStop() (issues []string) {
 	} else {
 		robots = e.trackerStateGc.Robots
 	}
-	robotsNearBall := e.findRobotInsideRadius(robots, e.trackerStateGc.Ball.Pos.ToVector2(), radius)
+	robotsNearBall := e.findRobotInsideRadius(robots, ballPos, radius)
 	if len(robotsNearBall) > 0 {
 		var robotsStr []string
 		for _, robot := range robotsNearBall {
@@ -236,14 +237,17 @@ func (e *Engine) readyToContinueFromStop() (issues []string) {
 		issues = append(issues, fmt.Sprintf("Robots too close to ball: %s", strings.Join(robotsStr, ", ")))
 	}
 	if e.currentState.PlacementPos != nil {
-		ballToPlacementPosDist := e.currentState.PlacementPos.DistanceTo(e.trackerStateGc.Ball.Pos.ToVector2())
+		ballToPlacementPosDist := e.currentState.PlacementPos.DistanceTo(ballPos)
 		if ballToPlacementPosDist > e.gameConfig.BallPlacementRequiredDistance {
 			issues = append(issues, fmt.Sprintf("Ball is %.2f m (>%.2f m) away from placement pos",
 				ballToPlacementPosDist, e.gameConfig.BallPlacementRequiredDistance))
 		}
 	}
 
-	ballPos := e.trackerStateGc.Ball.Pos.ToVector2()
+	if e.ballTooCloseToDefenseArea(ballPos) {
+		issues = append(issues, "Ball is too close to a defense area")
+	}
+
 	if math.Abs(ballPos.GetX64()) > e.getGeometry().FieldLength/2 ||
 		math.Abs(ballPos.GetY64()) > e.getGeometry().FieldWidth/2 {
 		issues = append(issues, fmt.Sprintf("Ball is outside of field: x: %.2f m, y: %.2f m",


### PR DESCRIPTION
Root Cause: The GC checks the 0.7m for ball placement, but not as a guard for actually continuing the game out of stop. This was most noticeable with force starts since referees/GCOs aren't used to required placement in those scenarios. This PR takes the inline check from placement (that confirms valid placement) and creates a function for it alongside ball in def area. This means ball state w.r.t. def area is cleanly abstracted in common.go. Then all locations needing the check (placement and game state advance) check using the same implementation so they don't diverge.

I have not test this yet on a real field/game scenario.

Fixes #210 